### PR TITLE
release: nop-lib v1.0.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-    "packages/nop-lib": "1.0.0",
+    "packages/nop-lib": "1.0.1",
     "packages/sam-lib": "0.1.1"
 }

--- a/packages/nop-lib/CHANGELOG.md
+++ b/packages/nop-lib/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.0.1](https://github.com/flovogt/test-lib-rp/compare/nop-lib-v1.0.0...nop-lib-v1.0.1) (2023-03-07)
+
+
+### Bug Fixes
+
+* add licence file ([c5fe49b](https://github.com/flovogt/test-lib-rp/commit/c5fe49b8c47a3371ca3e240df577c83fd7e7b52d))
+
 ## 1.0.0 (2023-01-24)
 
 

--- a/packages/nop-lib/package.json
+++ b/packages/nop-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nop-lib",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "Apache-2.0",
   "description": "The Test-Lib",
   "repository": {


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.0.1](https://github.com/flovogt/test-lib-rp/compare/nop-lib-v1.0.0...nop-lib-v1.0.1) (2023-03-07)


### Bug Fixes

* add licence file ([c5fe49b](https://github.com/flovogt/test-lib-rp/commit/c5fe49b8c47a3371ca3e240df577c83fd7e7b52d))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).